### PR TITLE
creates _redirects for /uses

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/uses https://kit.com/leveluptutorials/podcasting-screencasting-gear


### PR DESCRIPTION
points to https://kit.com/leveluptutorials/podcasting-screencasting-gear, the value listed in the readme from wesbos/awesome-uses

😂

context:
[![image](https://user-images.githubusercontent.com/622118/72085341-c1893a00-32ca-11ea-804c-36b72a784645.png)](https://twitter.com/stolinski/status/1215306305595822080)
